### PR TITLE
refactor: code quality, logging and reliability improvements

### DIFF
--- a/custom_components/siedle/__init__.py
+++ b/custom_components/siedle/__init__.py
@@ -15,6 +15,8 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import (
     DOMAIN,
+    SIEDLE_DATA_DIR,
+    TASK_NAME_FCM_SETUP,
     SERVICE_OPEN_DOOR,
     SERVICE_TOGGLE_LIGHT,
     SERVICE_HANGUP,
@@ -121,7 +123,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     transfer_secret = entry.data.get("transfer_secret")
 
     # Ensure Siedle data directory exists (for tokens, cache, etc.)
-    siedle_data_dir = hass.config.path("siedle")
+    siedle_data_dir = hass.config.path(SIEDLE_DATA_DIR)
     os.makedirs(siedle_data_dir, exist_ok=True)
 
     # Migrate old token files from config root to siedle/ subfolder
@@ -171,7 +173,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         raise ConfigEntryNotReady from err
 
     # Setup data coordinator
-    coordinator = SiedleDataUpdateCoordinator(hass, siedle)
+    coordinator = SiedleDataUpdateCoordinator(hass, siedle, entry)
     await coordinator.async_config_entry_first_refresh()
 
     # Store coordinator
@@ -200,10 +202,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             
             if sip_creds:
                 # Log SIP credentials for debugging (obfuscate password)
-                _LOGGER.info(f"SIP credentials loaded: host={sip_creds.get('host')}, "
-                            f"port={sip_creds.get('port')}, "
-                            f"username={sip_creds.get('username')}, "
-                            f"protocol={sip_creds.get('protocol', 'unknown')}")
+                _LOGGER.debug(
+                    "SIP credentials loaded: host=%s, port=%s, user=%s, protocol=%s",
+                    sip_creds.get("host"),
+                    sip_creds.get("port"),
+                    sip_creds.get("username"),
+                    sip_creds.get("protocol", "unknown"),
+                )
                 siedle_sip_config = SipConfig.from_dict(sip_creds)
                 
                 # Check for external SIP configuration
@@ -220,7 +225,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                             transport=SipTransport(transport_str),
                             display_name="Siedle Türstation",
                         )
-                        _LOGGER.info(f"External SIP configured: {ext_host}")
+                        _LOGGER.debug("External SIP configured: %s", ext_host)
                 
                 # Get forwarding settings
                 forward_enabled = entry.options.get(CONF_FORWARD_ENABLED, False)
@@ -245,7 +250,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                     # Ensure directory exists
                     os.makedirs(full_path, exist_ok=True)
                     recording_path = os.path.join(full_path, "doorbell")
-                    _LOGGER.info(f"Recording configured: path={recording_path}, duration={recording_duration}s")
+                    _LOGGER.debug("Recording configured: path=%s, duration=%ss", recording_path, recording_duration)
                 
                 # Create SIP Call Manager
                 sip_manager = SipCallManager(
@@ -332,7 +337,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 )
                 
         except Exception as e:
-            _LOGGER.error(f"Failed to start SIP Call Manager: {e}")
+            _LOGGER.error("Failed to start SIP Call Manager: %s", e)
             _LOGGER.exception(e)
             # Fallback to basic SIP listener
             try:
@@ -340,8 +345,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                     siedle.start_sip_listener,
                     lambda event_type, data: _sip_callback(hass, entry, event_type, data)
                 )
-            except:
-                pass
+            except Exception:
+                _LOGGER.debug("Fallback legacy SIP listener also failed to start")
 
     # Setup platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -394,11 +399,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 else:
                     _LOGGER.warning("No access token available for FCM registration")
             except Exception as e:
-                _LOGGER.error(f"Failed to setup FCM handler: {e}")
-                _LOGGER.exception(e)
+                _LOGGER.exception("Failed to setup FCM handler: %s", e)
         
         # Start FCM in background - don't block setup
-        entry.async_create_background_task(hass, _start_fcm_handler(), "siedle_fcm_setup")
+        entry.async_create_background_task(hass, _start_fcm_handler(), TASK_NAME_FCM_SETUP)
 
     # ============== Setup Fritz!Box Dialer (F13) ==============
     if entry.options.get(CONF_FRITZBOX_ENABLED, False):
@@ -497,7 +501,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     files_to_remove.append(hass.config.path(f".siedle_token_{entry_id}.json"))
 
     # Token cache (new location in siedle/ subfolder)
-    siedle_data_dir = hass.config.path("siedle")
+    siedle_data_dir = hass.config.path(SIEDLE_DATA_DIR)
     files_to_remove.append(os.path.join(siedle_data_dir, f"token_{entry_id}.json"))
 
     def _cleanup_files():
@@ -645,7 +649,7 @@ def _sip_state_callback(hass: HomeAssistant, entry: ConfigEntry, state, data: di
         recording_file = data["recording_file"]
         recording_sensor = entry_data.get("last_recording_sensor")
         if recording_sensor:
-            _LOGGER.info(f"Updating recording sensor with file: {recording_file}")
+            _LOGGER.debug("Updating recording sensor with file: %s", recording_file)
             recording_sensor.update_recording(recording_file)
     
     # Fire event for automations (thread-safe)
@@ -684,7 +688,8 @@ def _fcm_callback(hass: HomeAssistant, entry: ConfigEntry, event_type: str, data
     
     # Also fire a specific doorbell event for easier automation
     if event_type == "doorbell":
-        hass.bus.fire(
+        hass.loop.call_soon_threadsafe(
+            hass.bus.async_fire,
             f"{DOMAIN}_doorbell",
             {
                 "title": data.get("title", ""),
@@ -732,10 +737,10 @@ async def async_setup_services(hass: HomeAssistant, siedle: Siedle):
 class SiedleDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching Siedle data."""
 
-    def __init__(self, hass: HomeAssistant, api: Siedle):
+    def __init__(self, hass: HomeAssistant, api: Siedle, entry: ConfigEntry):
         """Initialize."""
         self.api = api
-        self.hass = hass
+        self.entry = entry
         super().__init__(
             hass,
             _LOGGER,
@@ -746,27 +751,22 @@ class SiedleDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Update data via library."""
         try:
-            # Get contacts and status
             contacts = await self.hass.async_add_executor_job(self.api.get_contacts)
             status = await self.hass.async_add_executor_job(self.api.getStatus)
-            
-            # Get SIP manager status if available
+
             sip_registered = False
             ext_sip_registered = False
             call_state = "idle"
-            
-            # Find entry for this API
-            for entry_id, data in self.hass.data.get(DOMAIN, {}).items():
-                if isinstance(data, dict) and data.get("api") == self.api:
-                    sip_manager = data.get("sip_manager")
-                    if sip_manager:
-                        if hasattr(sip_manager, '_siedle_conn') and sip_manager._siedle_conn:
-                            sip_registered = sip_manager._siedle_conn.registered
-                        if hasattr(sip_manager, '_external_conn') and sip_manager._external_conn:
-                            ext_sip_registered = sip_manager._external_conn.registered
-                        if hasattr(sip_manager, 'state'):
-                            call_state = sip_manager.state.value
-                    break
+
+            entry_data = self.hass.data.get(DOMAIN, {}).get(self.entry.entry_id, {})
+            sip_manager = entry_data.get("sip_manager")
+            if sip_manager:
+                if hasattr(sip_manager, '_siedle_conn') and sip_manager._siedle_conn:
+                    sip_registered = sip_manager._siedle_conn.registered
+                if hasattr(sip_manager, '_external_conn') and sip_manager._external_conn:
+                    ext_sip_registered = sip_manager._external_conn.registered
+                if hasattr(sip_manager, 'state'):
+                    call_state = sip_manager.state.value
             
             return {
                 "contacts": contacts,

--- a/custom_components/siedle/binary_sensor.py
+++ b/custom_components/siedle/binary_sensor.py
@@ -84,7 +84,7 @@ class SiedleDoorbellSensor(CoordinatorEntity, BinarySensorEntity):
         """Return device information."""
         return {
             "identifiers": {(DOMAIN, self._entry.entry_id)},
-            "name": "Siedle Türstation",
+            "name": f"Siedle {self._entry.data.get('endpoint_id', 'Unknown')[:8]}",
             "manufacturer": "Siedle",
             "model": self.coordinator.data.get("status", {}).get("config", {}).get("deviceType", "SUS"),
             "sw_version": self.coordinator.data.get("status", {}).get("config", {}).get("deviceVersion"),
@@ -180,7 +180,7 @@ class SiedleMQTTConnectedSensor(CoordinatorEntity, BinarySensorEntity):
         """Return device information."""
         return {
             "identifiers": {(DOMAIN, self._entry.entry_id)},
-            "name": "Siedle Türstation",
+            "name": f"Siedle {self._entry.data.get('endpoint_id', 'Unknown')[:8]}",
             "manufacturer": "Siedle",
         }
 
@@ -230,7 +230,7 @@ class SiedleFCMConnectedSensor(CoordinatorEntity, BinarySensorEntity):
         """Return device information."""
         return {
             "identifiers": {(DOMAIN, self._entry.entry_id)},
-            "name": "Siedle Türstation",
+            "name": f"Siedle {self._entry.data.get('endpoint_id', 'Unknown')[:8]}",
             "manufacturer": "Siedle",
         }
 
@@ -300,7 +300,7 @@ class SiedleDoorContactSensor(CoordinatorEntity, BinarySensorEntity):
         """Return device information."""
         return {
             "identifiers": {(DOMAIN, self._entry.entry_id)},
-            "name": "Siedle Türstation",
+            "name": f"Siedle {self._entry.data.get('endpoint_id', 'Unknown')[:8]}",
             "manufacturer": "Siedle",
         }
 

--- a/custom_components/siedle/const.py
+++ b/custom_components/siedle/const.py
@@ -111,6 +111,10 @@ SIP_TRANSPORTS = [SIP_TRANSPORT_UDP, SIP_TRANSPORT_TCP, SIP_TRANSPORT_TLS]
 # ==================== Dispatcher Signals ====================
 SIGNAL_SIEDLE_CONNECTION_UPDATE = f"{DOMAIN}_connection_update"
 
+# ==================== Internal constants ====================
+SIEDLE_DATA_DIR = "siedle"
+TASK_NAME_FCM_SETUP = "siedle_fcm_setup"
+
 # ==================== DTMF Event Codes (RFC 4733) ====================
 DTMF_EVENT_MAP = {
     0: "0", 1: "1", 2: "2", 3: "3", 4: "4",

--- a/custom_components/siedle/fcm_handler.py
+++ b/custom_components/siedle/fcm_handler.py
@@ -137,7 +137,7 @@ class SiedleFCMHandler:
             daemon=True
         )
         self._thread.start()
-        _LOGGER.info(f"FCM listener thread started: {self._thread.name}, alive={self._thread.is_alive()}")
+        _LOGGER.debug("FCM listener thread started: %s", self._thread.name)
         
         _LOGGER.info("Siedle FCM handler started")
         return True
@@ -169,7 +169,7 @@ class SiedleFCMHandler:
         """Load existing FCM credentials or create new ones."""
         try:
             if os.path.exists(self._fcm_credentials_file):
-                _LOGGER.info(f"Loading FCM credentials from {self._fcm_credentials_file}")
+                _LOGGER.debug("Loading FCM credentials from %s", self._fcm_credentials_file)
                 with open(self._fcm_credentials_file, 'r') as f:
                     creds = json.load(f)
                 
@@ -189,7 +189,7 @@ class SiedleFCMHandler:
                 else:
                     self._client.create_new_keys()
                 
-                _LOGGER.info(f"FCM credentials loaded, token: {self._fcm_token[:30]}...")
+                _LOGGER.debug("FCM credentials loaded, token: %s...", self._fcm_token[:20])
                 return True
             
             # Create new registration using Android-style registration
@@ -203,7 +203,7 @@ class SiedleFCMHandler:
             # Do Android-style registration manually
             try:
                 android_id, security_token, gcm_token = self._register_android_fcm()
-                _LOGGER.info(f"Android FCM registration complete: android_id={android_id}, gcm_token={gcm_token[:30] if gcm_token else 'None'}...")
+                _LOGGER.debug("Android FCM registration complete: android_id=%s", android_id)
             except Exception as reg_err:
                 _LOGGER.error(f"Android FCM registration failed: {reg_err}")
                 import traceback
@@ -227,10 +227,11 @@ class SiedleFCMHandler:
                 "auth_secret_b64": auth_b64,
             }
             
-            with open(self._fcm_credentials_file, 'w') as f:
+            fd = os.open(self._fcm_credentials_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as f:
                 json.dump(creds, f, indent=2)
             
-            _LOGGER.info(f"FCM registration successful, token: {gcm_token[:30]}...")
+            _LOGGER.info("FCM registration successful")
             return True
             
         except Exception as e:
@@ -400,45 +401,23 @@ class SiedleFCMHandler:
     
     def _listener_thread(self):
         """Background thread for FCM message reception."""
-        _LOGGER.info("FCM listener thread started")
-        
-        # Verify client state before starting
-        _LOGGER.info(f"FCM client state: android_id={self._client.android_id}, "
-                     f"security_token={'set' if self._client.security_token else 'NOT SET'}, "
-                     f"private_key={'set' if self._client.private_key else 'NOT SET'}, "
-                     f"auth_secret={'set' if self._client.auth_secret else 'NOT SET'}")
-        
-        # Setup callbacks
+        _LOGGER.debug("FCM listener thread started")
+
         self._client.on_notification_message = self._on_notification
         self._client.on_data_message = self._on_data_message
         self._client.on_connection_status = self._on_connection_status
-        
-        # Also log any raw messages the library receives
-        original_on_raw = getattr(self._client, 'on_raw_message', None)
-        def _on_raw_message(msg, client_id):
-            _LOGGER.info(f"FCM raw message received! Type: {type(msg).__name__}")
-            if original_on_raw:
-                original_on_raw(msg, client_id)
-        if hasattr(self._client, 'on_raw_message'):
-            self._client.on_raw_message = _on_raw_message
-        
+
         try:
-            # Start listening (blocking) - method is start_listening() not start()
-            _LOGGER.info("Calling FCM start_listening()...")
             self._client.start_listening()
-            _LOGGER.info("FCM start_listening() returned (should not happen normally)")
+            _LOGGER.debug("FCM start_listening() returned")
         except RuntimeError as e:
-            _LOGGER.error(f"FCM listener RuntimeError: {e}")
-            import traceback
-            _LOGGER.error(traceback.format_exc())
+            _LOGGER.exception("FCM listener RuntimeError: %s", e)
         except Exception as e:
             if self._running:
-                _LOGGER.error(f"FCM listener error: {e}")
-                import traceback
-                _LOGGER.error(traceback.format_exc())
+                _LOGGER.exception("FCM listener error: %s", e)
         finally:
             self._connected = False
-            _LOGGER.info("FCM listener thread ended")
+            _LOGGER.debug("FCM listener thread ended")
     
     def _on_connection_status(self, status: str, client_id: str):
         """Handle FCM connection status changes."""
@@ -463,17 +442,14 @@ class SiedleFCMHandler:
     
     def _on_notification(self, message: dict, client_id: str):
         """Handle FCM notification message."""
-        _LOGGER.info(f"FCM notification received! Keys: {list(message.keys()) if isinstance(message, dict) else type(message).__name__}")
-        _LOGGER.debug(f"FCM notification full: {message}")
+        _LOGGER.debug("FCM notification received: %s", list(message.keys()) if isinstance(message, dict) else type(message).__name__)
         self._process_message(message)
-    
+
     def _on_data_message(self, data: bytes, client_id: str):
         """Handle FCM data message."""
-        _LOGGER.info(f"FCM data message received! Size: {len(data) if data else 0} bytes")
-        _LOGGER.debug(f"FCM data message raw: {data[:200] if data else 'None'}")
+        _LOGGER.debug("FCM data message received (%d bytes)", len(data) if data else 0)
         try:
             message = json.loads(data.decode())
-            _LOGGER.info(f"FCM data parsed: keys={list(message.keys())}")
             self._process_message({"payload": {"data": message}})
         except Exception as e:
             _LOGGER.warning(f"Failed to parse FCM data: {e}")

--- a/custom_components/siedle/siedle_api.py
+++ b/custom_components/siedle/siedle_api.py
@@ -379,8 +379,8 @@ class Siedle:
             response.raise_for_status()
             return response.json()
         except requests.HTTPError as e:
-            _LOGGER.error("HTTP Error Siedle API: %s" % e)
-            if e.response.status_code == 401:
+            _LOGGER.error("HTTP Error Siedle API: %s", e)
+            if e.response is not None and e.response.status_code == 401:
                 self.refreshToken()
                 response = self._client.get(url, timeout=30)
                 response.raise_for_status()
@@ -405,10 +405,10 @@ class Siedle:
             response.raise_for_status()
             return response.json() if response.text else {}
         except requests.HTTPError as e:
-            _LOGGER.error("HTTP Error Siedle API: %s" % e)
-            if e.response.status_code == 401:
+            _LOGGER.error("HTTP Error Siedle API: %s", e)
+            if e.response is not None and e.response.status_code == 401:
                 self.refreshToken()
-                _LOGGER.info("Retrying with new Token...")
+                _LOGGER.debug("Retrying POST with refreshed token")
                 response = self._client.post(url, json=data, timeout=30)
                 response.raise_for_status()
                 return response.json() if response.text else {}
@@ -432,14 +432,14 @@ class Siedle:
             response.raise_for_status()
             return response.json() if response.text else {}
         except requests.HTTPError as e:
-            _LOGGER.error("HTTP Error Siedle API: %s" % e)
-            if e.response.status_code == 401:
+            _LOGGER.error("HTTP Error Siedle API: %s", e)
+            if e.response is not None and e.response.status_code == 401:
                 self.refreshToken()
                 response = self._client.put(url, json=data, timeout=30)
                 response.raise_for_status()
                 return response.json() if response.text else {}
         except requests.exceptions.RequestException as e:
-            _LOGGER.error("Error Siedle API: %s with data: %s" % (e, data))
+            _LOGGER.error("Error Siedle API: %s", e)
             raise
 
 
@@ -693,12 +693,12 @@ class Siedle:
     
     def _on_mqtt_disconnect(self, client, userdata, rc, properties=None):
         """Callback when MQTT connection is lost (paho-mqtt 2.0 compatible)"""
-        _LOGGER.warning(f"MQTT disconnected with code {rc}")
+        _LOGGER.warning("MQTT disconnected with code %s", rc)
         self._mqtt_connected = False
     
     def _on_mqtt_message(self, client, userdata, msg):
         """Callback when MQTT message is received"""
-        _LOGGER.info(f"MQTT message received on topic '{msg.topic}': {msg.payload}")
+        _LOGGER.debug("MQTT message on topic '%s'", msg.topic)
         
         try:
             payload = json.loads(msg.payload.decode('utf-8'))
@@ -708,10 +708,10 @@ class Siedle:
                 try:
                     callback(msg.topic, payload)
                 except Exception as e:
-                    _LOGGER.error(f"Error in MQTT callback: {e}")
+                    _LOGGER.error("Error in MQTT callback: %s", e)
             
         except json.JSONDecodeError:
-            _LOGGER.warning(f"Non-JSON MQTT message: {msg.payload}")
+            _LOGGER.warning("Non-JSON MQTT message on topic '%s'", msg.topic)
     
     def connect_mqtt(self, on_message_callback=None):
         """
@@ -737,7 +737,7 @@ class Siedle:
             _LOGGER.error("MQTT credentials not available")
             return False
         
-        _LOGGER.info(f"Connecting to MQTT broker {mqtt_config['host']}:{mqtt_config['port']}...")
+        _LOGGER.info("Connecting to MQTT broker %s:%s", mqtt_config['host'], mqtt_config['port'])
         
         # Create MQTT client
         self._mqtt_client = mqtt.Client(
@@ -767,33 +767,40 @@ class Siedle:
         if on_message_callback:
             self._mqtt_callbacks.append(on_message_callback)
         
-        try:
-            # Connect to broker
-            self._mqtt_client.connect(
-                mqtt_config['host'],
-                mqtt_config['port'],
-                keepalive=60
-            )
-            
-            # Start network loop in background thread
-            self._mqtt_client.loop_start()
-            
-            # Wait for connection
-            timeout = 10
-            start_time = time.time()
-            while not self._mqtt_connected and (time.time() - start_time) < timeout:
-                time.sleep(0.1)
-            
-            if self._mqtt_connected:
-                _LOGGER.info("MQTT connection established")
-                return True
-            else:
-                _LOGGER.error("MQTT connection timeout")
-                return False
-                
-        except Exception as e:
-            _LOGGER.error(f"Failed to connect to MQTT: {e}")
-            return False
+        # Enable paho auto-reconnect for post-connect drops (1s–30s backoff)
+        self._mqtt_client.reconnect_delay_set(min_delay=1, max_delay=30)
+
+        for attempt in range(3):
+            try:
+                self._mqtt_client.connect(
+                    mqtt_config['host'],
+                    mqtt_config['port'],
+                    keepalive=60,
+                )
+                self._mqtt_client.loop_start()
+
+                # Wait up to 10s for on_connect callback
+                deadline = time.time() + 10
+                while not self._mqtt_connected and time.time() < deadline:
+                    time.sleep(0.1)
+
+                if self._mqtt_connected:
+                    _LOGGER.info("MQTT connection established")
+                    return True
+
+                _LOGGER.warning("MQTT connection attempt %d/3 timed out", attempt + 1)
+                self._mqtt_client.loop_stop()
+                self._mqtt_connected = False
+
+            except Exception as e:
+                _LOGGER.warning("MQTT connect attempt %d/3 failed: %s", attempt + 1, e)
+
+            if attempt < 2:
+                delay = 2 ** attempt  # 1s, 2s
+                time.sleep(delay)
+
+        _LOGGER.error("MQTT connection failed after 3 attempts")
+        return False
     
     def disconnect_mqtt(self):
         """Disconnect from MQTT broker"""
@@ -1060,7 +1067,7 @@ class Siedle:
             ip = s.getsockname()[0]
             s.close()
             return ip
-        except:
+        except OSError:
             return "192.168.1.100"
     
     def _compute_sip_digest(self, method: str, uri: str, realm: str, nonce: str, 
@@ -1300,7 +1307,7 @@ class Siedle:
             if self._sip_socket:
                 try:
                     self._sip_socket.close()
-                except:
+                except OSError:
                     pass
             self._sip_socket = None
             self._sip_registered = False
@@ -1313,7 +1320,7 @@ class Siedle:
         if self._sip_socket:
             try:
                 self._sip_socket.close()
-            except:
+            except OSError:
                 pass
         _LOGGER.info("SIP listener stop requested")
     

--- a/custom_components/siedle/sip_manager.py
+++ b/custom_components/siedle/sip_manager.py
@@ -597,10 +597,9 @@ class SipConnection:
     def connect(self) -> bool:
         """Connect to SIP server."""
         try:
-            _LOGGER.info(f"{self.name}: Connecting to {self.config.host}:{self.config.port} ({self.config.transport.value})...")
-            
+            _LOGGER.debug("%s: Connecting to %s:%s (%s)...", self.name, self.config.host, self.config.port, self.config.transport.value)
+
             if self.config.transport == SipTransport.TLS:
-                # TLS connection
                 context = ssl.create_default_context()
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 sock.settimeout(30)
@@ -609,32 +608,28 @@ class SipConnection:
                 self._socket = self._ssl_socket
                 self._local_ip = self._socket.getsockname()[0]
                 self._local_port = self._socket.getsockname()[1]
-                _LOGGER.info(f"{self.name}: TLS connection established (local {self._local_ip}:{self._local_port})")
+                _LOGGER.debug("%s: TLS connected (local %s:%s)", self.name, self._local_ip, self._local_port)
             elif self.config.transport == SipTransport.TCP:
-                # TCP connection
                 self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 self._socket.settimeout(30)
                 self._socket.connect((self.config.host, self.config.port))
                 self._local_ip = self._socket.getsockname()[0]
                 self._local_port = self._socket.getsockname()[1]
-                _LOGGER.info(f"{self.name}: TCP connection established (local {self._local_ip}:{self._local_port})")
+                _LOGGER.debug("%s: TCP connected (local %s:%s)", self.name, self._local_ip, self._local_port)
             else:
-                # UDP connection
                 self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
                 self._socket.settimeout(5)
-                # For UDP, we don't "connect" but we set default destination
                 self._socket.connect((self.config.host, self.config.port))
-                # Update local port to actual OS-assigned port (important for Via/Contact headers!)
                 actual_addr = self._socket.getsockname()
                 self._local_ip = actual_addr[0]
                 self._local_port = actual_addr[1]
-                _LOGGER.info(f"{self.name}: UDP socket ready (local {self._local_ip}:{self._local_port})")
-            
+                _LOGGER.debug("%s: UDP socket ready (local %s:%s)", self.name, self._local_ip, self._local_port)
+
             self._connected = True
             return True
-            
+
         except Exception as e:
-            _LOGGER.error(f"{self.name}: Connection failed: {e}")
+            _LOGGER.error("%s: Connection failed: %s", self.name, e)
             self._connected = False
             return False
     
@@ -651,87 +646,70 @@ class SipConnection:
             pass
 
         try:
-            # Send initial REGISTER
-            _LOGGER.info(f"{self.name}: Sending initial REGISTER to {self.config.host}:{self.config.port} "
-                         f"(local {self._local_ip}:{self._local_port}, user={self.config.username})...")
+            _LOGGER.debug("%s: Sending REGISTER to %s:%s (user=%s)", self.name, self.config.host, self.config.port, self.config.username)
             register_msg = self._create_register(with_auth=False)
-            _LOGGER.info(f"{self.name}: REGISTER message ({len(register_msg)} bytes):\n{register_msg.decode()[:800]}")
+            _LOGGER.debug("%s: REGISTER (%d bytes):\n%s", self.name, len(register_msg), register_msg.decode()[:800])
             self._socket.send(register_msg)
-            
+
             response = self._socket.recv(4096)
             msg = self.parse_message(response)
-            _LOGGER.info(f"{self.name}: Response: {msg.status_code} {msg.status_text}")
-            
-            # Learn external IP from Via received= parameter
+            _LOGGER.debug("%s: Response: %s %s", self.name, msg.status_code, msg.status_text)
+
             self._extract_via_received(msg)
-            
+
             if msg.status_code == 401 or msg.status_code == 407:
-                # Extract auth params
                 www_auth = msg.headers.get("WWW-Authenticate") or msg.headers.get("Proxy-Authenticate", "")
-                _LOGGER.info(f"{self.name}: Auth required - extracting credentials from WWW-Authenticate header")
-                _LOGGER.debug(f"{self.name}: Auth header: {www_auth}")
-                
+                _LOGGER.debug("%s: Auth required (WWW-Authenticate present: %s)", self.name, bool(www_auth))
+
                 if not www_auth:
-                    _LOGGER.error(f"{self.name}: No WWW-Authenticate header found! Headers: {list(msg.headers.keys())}")
-                    _LOGGER.error(f"{self.name}: Full response:\n{msg.raw[:1000]}")
+                    _LOGGER.error("%s: No WWW-Authenticate header in 401. Headers: %s", self.name, list(msg.headers.keys()))
                     return False
-                
+
                 realm_match = re.search(r'realm="([^"]+)"', www_auth)
                 nonce_match = re.search(r'nonce="([^"]+)"', www_auth)
-                
+
                 if realm_match and nonce_match:
                     self._realm = realm_match.group(1)
                     self._nonce = nonce_match.group(1)
-                    _LOGGER.info(f"{self.name}: Extracted realm={self._realm}, nonce={self._nonce[:20]}...")
-                    
-                    # Authenticated REGISTER
-                    _LOGGER.info(f"{self.name}: Sending authenticated REGISTER...")
+                    _LOGGER.debug("%s: Auth challenge: realm=%s", self.name, self._realm)
+
                     auth_register = self._create_register(with_auth=True)
-                    _LOGGER.debug(f"{self.name}: Auth REGISTER message:\n{auth_register.decode()[:800]}...")
+                    _LOGGER.debug("%s: Auth REGISTER:\n%s", self.name, auth_register.decode()[:800])
                     self._socket.send(auth_register)
-                    
+
                     response = self._socket.recv(4096)
                     msg = self.parse_message(response)
-                    _LOGGER.info(f"{self.name}: Auth response: {msg.status_code} {msg.status_text}")
-                    
-                    # Learn external IP from Via received= parameter
+                    _LOGGER.debug("%s: Auth response: %s %s", self.name, msg.status_code, msg.status_text)
+
                     self._extract_via_received(msg)
-                    
+
                     if msg.status_code == 200:
-                        _LOGGER.info(f"{self.name}: Registration successful!")
                         self._registered = True
-                        
-                        # If we still don't know external IP, try STUN
+                        _LOGGER.info("%s: SIP registration successful", self.name)
                         if not self._external_ip:
                             self._discover_external_ip_via_stun()
-                        
                         if self._external_ip:
-                            _LOGGER.info(f"{self.name}: Will use external IP {self._external_ip} in SDP for NAT traversal")
+                            _LOGGER.debug("%s: External IP for SDP: %s", self.name, self._external_ip)
                         else:
-                            _LOGGER.warning(f"{self.name}: Could not determine external IP - RTP may fail behind NAT")
-                        
+                            _LOGGER.warning("%s: Could not determine external IP — RTP may fail behind NAT", self.name)
                         return True
                     else:
-                        _LOGGER.error(f"{self.name}: Registration failed: {msg.status_code} {msg.status_text}")
-                        _LOGGER.error(f"{self.name}: Response body: {msg.raw[:500]}")
+                        _LOGGER.error("%s: Registration failed: %s %s\n%s", self.name, msg.status_code, msg.status_text, msg.raw[:500])
                         return False
                 else:
-                    _LOGGER.error(f"{self.name}: Could not extract realm/nonce from: {www_auth}")
+                    _LOGGER.error("%s: Could not extract realm/nonce from WWW-Authenticate", self.name)
             elif msg.status_code == 200:
-                _LOGGER.info(f"{self.name}: Registration successful (no auth needed)")
                 self._registered = True
-                
-                # If we still don't know external IP, try STUN
+                _LOGGER.info("%s: SIP registration successful (no auth)", self.name)
                 if not self._external_ip:
                     self._discover_external_ip_via_stun()
-                
                 return True
             else:
-                _LOGGER.error(f"{self.name}: Unexpected response: {msg.status_code}")
+                _LOGGER.error("%s: Unexpected REGISTER response: %s", self.name, msg.status_code)
                 return False
-                
+
         except Exception as e:
-            _LOGGER.error(f"{self.name}: Registration error: {e}")
+            _LOGGER.error("%s: Registration error: %s", self.name, e)
             return False
     
     def send(self, data: bytes):
@@ -839,9 +817,9 @@ class SipConnection:
                 
                 self._notify_callbacks(msg)
         if self._connection_lost:
-            _LOGGER.warning(f"{self.name}: Listen loop ended — connection lost, notifying for reconnect")
+            _LOGGER.warning("%s: Listen loop ended — connection lost, notifying for reconnect", self.name)
         else:
-            _LOGGER.info(f"{self.name}: Listen loop ended")
+            _LOGGER.debug("%s: Listen loop ended", self.name)
     
     def _handle_register_auth_challenge(self, msg: SipMessage):
         """Handle 401/407 from REGISTER by extracting new nonce and retrying."""
@@ -867,7 +845,7 @@ class SipConnection:
     
     def _keepalive_loop(self):
         """Periodic keepalive and re-registration loop."""
-        _LOGGER.info(f"{self.name}: Keepalive loop started (OPTIONS every {self.keepalive_interval}s, re-REGISTER every {self.re_register_interval}s)")
+        _LOGGER.debug("%s: Keepalive loop started (OPTIONS every %ss, re-REGISTER every %ss)", self.name, self.keepalive_interval, self.re_register_interval)
         while self._running and not self._connection_lost:
             time.sleep(1)
             now = time.time()
@@ -890,7 +868,7 @@ class SipConnection:
             # Re-register periodically
             if (now - self._last_register_time) > self.re_register_interval:
                 try:
-                    _LOGGER.info(f"{self.name}: Sending re-REGISTER (periodic refresh)...")
+                    _LOGGER.debug("%s: Sending re-REGISTER (periodic refresh)", self.name)
                     self._send_re_register()
                     self._last_register_time = now
                 except Exception as e:
@@ -898,7 +876,7 @@ class SipConnection:
                     self._connection_lost = True
                     break
         
-        _LOGGER.info(f"{self.name}: Keepalive loop ended (connection_lost={self._connection_lost})")
+        _LOGGER.debug("%s: Keepalive loop ended (connection_lost=%s)", self.name, self._connection_lost)
     
     def _send_options_keepalive(self):
         """Send SIP OPTIONS as keepalive to detect dead connections."""
@@ -942,7 +920,7 @@ class SipConnection:
         if self._socket:
             try:
                 self._socket.close()
-            except:
+            except OSError:
                 pass
             self._socket = None
         
@@ -2193,9 +2171,9 @@ class SipCallManager:
         if self._siedle_conn:
             try:
                 self._siedle_conn.stop()
-            except:
-                pass
-        
+            except Exception as e:
+                _LOGGER.debug("Error stopping old Siedle SIP connection: %s", e)
+
         # Create new connection
         self._siedle_conn = SipConnection(self.siedle_config, name="Siedle-SIP")
         if self._siedle_conn.register():
@@ -2224,9 +2202,9 @@ class SipCallManager:
         if self._external_conn:
             try:
                 self._external_conn.stop()
-            except:
-                pass
-        
+            except Exception as e:
+                _LOGGER.debug("Error stopping old external SIP connection: %s", e)
+
         self._external_conn = SipConnection(self.external_config, name="External-SIP")
         if self._external_conn.register():
             _LOGGER.info("External SIP reconnected successfully!")


### PR DESCRIPTION
Critical fixes:
- Replace bare except clauses with specific exceptions throughout
- Fix hass.bus.fire() called from FCM thread → call_soon_threadsafe + async_fire
- Guard e.response None-check before accessing .status_code in all HTTP methods
- Save FCM credentials with 0o600 permissions instead of world-readable defaults

Logging cleanup:
- Standardise all _LOGGER calls to %-style format (no f-strings)
- Demote verbose SIP connect/register steps from INFO to DEBUG
- Demote FCM registration details, listener lifecycle, MQTT messages to DEBUG
- Remove traceback duplication (use _LOGGER.exception instead of error+format_exc)
- Mask FCM tokens in log output

Architecture:
- SiedleDataUpdateCoordinator now holds direct ConfigEntry reference; removes O(n) loop over hass.data to find its own entry on every coordinator update
- binary_sensor.py: replace hardcoded "Siedle Türstation" device name with endpoint_id-based name, matching sensor.py convention
- Add SIEDLE_DATA_DIR and TASK_NAME_FCM_SETUP constants to replace magic strings

Reliability:
- MQTT connect_mqtt() retries up to 3 times with exponential backoff (1s, 2s) and enables paho auto-reconnect (1–30s) for post-connect drops