### PR TITLE
fix(fcm): retry GCM register on transient PHONE_REGISTRATION_ERROR

### DIFF
--- a/custom_components/siedle/fcm_handler.py
+++ b/custom_components/siedle/fcm_handler.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import threading
+import time
 from datetime import datetime
 from typing import Callable, Optional, Dict, Any
 
@@ -296,16 +297,40 @@ class SiedleFCMHandler:
             "gcm_sender_id": SIEDLE_FIREBASE["sender_id"],
         }
         
-        gcm_token = send_gcm_register_request(
-            android_id=android_id,
-            security_token=security_token,
-            app_id=SIEDLE_FIREBASE["app_id"],
-            android_app=android_app,
-            installation_auth_token=installation_token,
-        )
-        _LOGGER.info(f"GCM Register OK: token={gcm_token[:30]}...")
-        
-        return android_id, security_token, gcm_token
+        # Google's GCM register frequently returns a transient
+        # PHONE_REGISTRATION_ERROR right after check-in because the freshly
+        # minted android_id needs a few seconds to propagate on Google's
+        # backend. The official push_receiver/firebase-messaging clients retry
+        # this call; upstream fcm_receiver does not, so we retry here.
+        # Runs in an executor thread (via async_add_executor_job), so the
+        # blocking sleep does not stall the event loop.
+        max_attempts = 5
+        retry_delay = 5
+        last_err = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                gcm_token = send_gcm_register_request(
+                    android_id=android_id,
+                    security_token=security_token,
+                    app_id=SIEDLE_FIREBASE["app_id"],
+                    android_app=android_app,
+                    installation_auth_token=installation_token,
+                )
+                _LOGGER.info(f"GCM Register OK: token={gcm_token[:30]}...")
+                return android_id, security_token, gcm_token
+            except RuntimeError as e:
+                last_err = e
+                if "PHONE_REGISTRATION_ERROR" in str(e) and attempt < max_attempts:
+                    _LOGGER.warning(
+                        "GCM register attempt %d/%d failed (%s); retrying in %ds...",
+                        attempt, max_attempts, e, retry_delay,
+                    )
+                    time.sleep(retry_delay)
+                    continue
+                raise
+
+        # Should not be reachable (loop either returns or raises), but be safe.
+        raise last_err
     
     def _encrypt_name(self, name: str) -> Optional[str]:
         """Encrypt device name using AES/CBC with shared secret.


### PR DESCRIPTION
### Kontext

Ich nutze ein **Siedle IQ HTS (WLAN-fähiges In-Home-Gerät)** und bin bei der Einrichtung auf folgendes Problem gestoßen: Tür öffnen funktionierte einwandfrei, aber ich habe **keine eingehenden Anruf-/Klingel-Events** erhalten. In der iOS-App wurde der Endpoint zwar als registriert angezeigt, allerdings **ohne Namen**.

### Ursache

Die Logs zeigten, dass die FCM-Registrierung dauerhaft fehlschlägt:

```
Android FCM registration failed: PHONE_REGISTRATION_ERROR
File ".../fcm_receiver/http_client.py", line 118, in send_gcm_register_request
    raise RuntimeError(parsed["Error"][0])
RuntimeError: PHONE_REGISTRATION_ERROR
```

Der GCM-Register-Schritt (Schritt 3 der Android-FCM-Registrierung) liefert von Googles Servern häufig einen **transienten** `PHONE_REGISTRATION_ERROR` unmittelbar nach dem Check-in zurück, weil die frisch erzeugte `android_id` einige Sekunden braucht, um im Backend von Google propagiert zu werden.

`send_gcm_register_request` wird in `_register_android_fcm()` aktuell **nur einmal** aufgerufen. Ein einzelner transienter Fehler deaktiviert FCM daher dauerhaft (bis zum Neustart). In der Folge wird **kein Push-Token bei Siedle registriert** – wodurch der Endpoint namenlos bleibt **und** keine Klingel-Events empfängt. Damit hängen alle drei oben genannten Symptome an derselben Ursache.

### Lösung

`send_gcm_register_request` wird in eine **Retry-Schleife (5 Versuche, je 5 s Pause)** gekapselt, die ausschließlich bei `PHONE_REGISTRATION_ERROR` erneut versucht. Jeder andere Fehler wird unverändert sofort weitergereicht.

Dies entspricht dem Verhalten der etablierten Bibliotheken `push_receiver` / `firebase-messaging`, die genau diesen transienten Fehler ebenfalls erneut versuchen. Das Upstream-`fcm_receiver` tut dies nicht.

Der Code läuft über `async_add_executor_job` in einem Executor-Thread, das blockierende `time.sleep` blockiert daher **nicht** den Event-Loop.

### Test

Getestet auf:
- Home Assistant OS 17.3 / Core 2026.6.1 (Python 3.14.5)
- Siedle IQ HTS (WLAN)

Nach dem Patch:
- ✅ FCM-Registrierung erfolgreich (`GCM Register OK` → `FCM token registered with Siedle successfully`)
- ✅ Endpoint erscheint nun **mit Namen** in der App
- ✅ Eingehende Klingel-Events werden empfangen

